### PR TITLE
Nightly ETL Bot: auto-fixes

### DIFF
--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -22,8 +22,8 @@ jobs:
   etl:
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+      group: nightly-etl
+      cancel-in-progress: false
     defaults:
       run:
         working-directory: permit_leads


### PR DESCRIPTION
Automated fixes for `.github/workflows/ingest-nightly.yml`:
- Ensure output dirs (logs/artifacts/data)
- Conditional ingestion (records>0 OR force=true)
- Correct log tail (logs/etl_output.log)
- Single artifact uploader with stable globs
- Concurrency guard